### PR TITLE
Remove invalid check in CommandLineBuilder

### DIFF
--- a/src/Utilities/CommandLineBuilder.cs
+++ b/src/Utilities/CommandLineBuilder.cs
@@ -302,9 +302,6 @@ namespace Microsoft.Build.Utilities
                 }
                 if (literalQuotes > 0)
                 {
-                    // Command line parsers typically break if you attempt to pass in an odd number of
-                    // escaped double quotes. We can only error if there isn't an even number.
-                    ErrorUtilities.VerifyThrowArgument(((literalQuotes % 2) == 0), "General.StringsCannotContainOddNumberOfDoubleQuotes", unquotedTextToAppend);
                     // Replace any \" sequences with \\"
                     unquotedTextToAppend = unquotedTextToAppend.Replace("\\\"", "\\\\\"");
                     // Now replace any " with \"


### PR DESCRIPTION
When escaping quotes, a check was done to ensure that the number of quotes that will be escaped is even. This doesn't make sense, since there's plenty of command line parsers (including Windows's own `CreateProcess`) that correctly process any number of embedded quotes (as long as they're escaped properly).

The effects of this check can be seen, by the way, by attempting to define a macro in the project properties for a C++ file which has in its body an odd number of quotes (e.g. a string with an embedded quote). Add `FOO="\""` to the C++ Preprocessor Definitions in the property pages and observe the MSB6001 error that results when you attempt to build.
